### PR TITLE
Added option for a callback function when the main channel of a SPICE session is closed

### DIFF
--- a/options.go
+++ b/options.go
@@ -55,3 +55,13 @@ func defaultDialer() func(context.Context, string, string) (net.Conn, error) {
 func defaultLogger() Logger {
 	return Adapt(logrus.New().WithField("app", "spiceProxy"))
 }
+
+// WithConnectionCloseHandler is called when the main channel of a SPICE session is closed.
+// The "destination" parameter contains the compute node address returned by "resolveComputeAddress".
+// WithConnectionCloseHandler can be used to clean up after a SPICE connection was closed
+func WithConnectionCloseHandler(closeCallback func(destination string)) Option {
+	return func(p *Proxy) error {
+		p.closeCallback = closeCallback
+		return nil
+	}
+}

--- a/options.go
+++ b/options.go
@@ -59,7 +59,7 @@ func defaultLogger() Logger {
 // WithConnectionCloseHandler is called when the main channel of a SPICE session is closed.
 // The "destination" parameter contains the compute node address returned by "resolveComputeAddress".
 // WithConnectionCloseHandler can be used to clean up after a SPICE connection was closed
-func WithConnectionCloseHandler(closeCallback func(destination string)) Option {
+func WithConnectionCloseHandler(closeCallback func(destination string) error) Option {
 	return func(p *Proxy) error {
 		p.closeCallback = closeCallback
 		return nil

--- a/proxy.go
+++ b/proxy.go
@@ -27,7 +27,7 @@ type Proxy struct {
 	sessionTable *sessionTable
 
 	// optional function called when main channel is closed
-	closeCallback func(destination string)
+	closeCallback func(destination string) error
 }
 
 // New returns a new *Proxy with the options applied
@@ -108,7 +108,10 @@ func (p *Proxy) ServeConn(tenant net.Conn) error {
 
 	// if connection was closed and it's the main channel, call the closeCallback
 	if handShake.channelType == red.ChannelMain && p.closeCallback != nil {
-		p.closeCallback(handShake.destination)
+		handShake.log.Info("clossing connection of main channel")
+		if err := p.closeCallback(handShake.destination); err != nil {
+			handShake.log.WithError(err).Error("error in connection closing callback")
+		}
 	}
 
 	handShake.log.Info("connection closed")


### PR DESCRIPTION
I needed to call some clean-up-code whenever a SPICE session is closed (stopping VMs in libvirtd), so I added a callback that is run when the SPICE main channel is closed.